### PR TITLE
Emit explicit object type and drop null-only types in OpenAPI output

### DIFF
--- a/JsonSchema/src/JsonSchemaBuilder.php
+++ b/JsonSchema/src/JsonSchemaBuilder.php
@@ -79,6 +79,7 @@ final class JsonSchemaBuilder
 
     public function generateFromSchema(Schema $schema, Definition $def): void
     {
+        $def->addType('object');
         $def->setAdditionalProperties($schema->isAdditionalPropertiesAllowed());
 
         foreach ($schema->getProperties() as $name => $property) {

--- a/JsonSchema/tests/JsonSchemaBuilderTest.php
+++ b/JsonSchema/tests/JsonSchemaBuilderTest.php
@@ -53,6 +53,25 @@ final class JsonSchemaBuilderTest extends TestCase
         self::assertArrayNotHasKey('example', $address);
     }
 
+    public function testObjectSchemasHaveExplicitObjectType(): void
+    {
+        $referenced = new Schema();
+        $referenced->prop('street')->string();
+
+        $schema = new Schema();
+        $schema->prop('address')->ref($referenced);
+        $schema->prop('addresses')->arrayOf($referenced);
+
+        $spec = (new JsonSchemaBuilder())->build($schema);
+
+        self::assertSame('object', $spec['type'] ?? null);
+
+        $properties = $spec['properties'] ?? [];
+        self::assertSame('object', $properties['address']['type'] ?? null);
+        self::assertSame('array', $properties['addresses']['type'] ?? null);
+        self::assertSame('object', $properties['addresses']['items']['type'] ?? null);
+    }
+
     public function testScalarPropertyDocumentationIsUnchanged(): void
     {
         $schema = new Schema();

--- a/OpenApi/src/OpenApiBuilder.php
+++ b/OpenApi/src/OpenApiBuilder.php
@@ -111,18 +111,33 @@ final class OpenApiBuilder
             unset($data['$schema']);
 
             $this->arrayWalkRecursive($data, '', static function (&$value, $key, &$parent, $context): void {
-                if ($context !== 'properties' && $key === 'type' && is_array($value)) {
-                    if (in_array('null', $value, true)) {
-                        $parent['nullable'] = true;
-                        unset($value[array_search('null', $value, true)]);
-                    }
-
-                    if (count($value) > 1) {
-                        throw new LogicException('Multiple types not supported.');
-                    }
-
-                    $value = reset($value);
+                if ($context === 'properties' || $key !== 'type') {
+                    return;
                 }
+
+                // OpenAPI 3.0 has no null type, and nullable is only allowed
+                // alongside another type. A null-only type is dropped entirely,
+                // leaving a schema that accepts any value.
+                if ($value === 'null' || $value === ['null']) {
+                    unset($parent[$key]);
+
+                    return;
+                }
+
+                if (!is_array($value)) {
+                    return;
+                }
+
+                if (in_array('null', $value, true)) {
+                    $parent['nullable'] = true;
+                    unset($value[array_search('null', $value, true)]);
+                }
+
+                if (count($value) > 1) {
+                    throw new LogicException('Multiple types not supported.');
+                }
+
+                $value = reset($value);
             });
 
             $list[$schemaClass] = $data;

--- a/OpenApi/tests/OpenApiBuilderTest.php
+++ b/OpenApi/tests/OpenApiBuilderTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Davajlama\Schemator\OpenApi\Tests;
+
+use Davajlama\Schemator\OpenApi\Api;
+use Davajlama\Schemator\OpenApi\OpenApiBuilder;
+use Davajlama\Schemator\Schema\Schema;
+use PHPUnit\Framework\TestCase;
+
+final class OpenApiBuilderTest extends TestCase
+{
+    public function testComponentSchemasHaveExplicitObjectType(): void
+    {
+        $address = new Schema('Address');
+        $address->prop('street')->string();
+
+        $order = new Schema('Order');
+        $order->prop('address')->ref($address);
+        $order->prop('packages')->arrayOf($address);
+
+        $component = $this->buildComponent($order);
+
+        self::assertSame('object', $component['type'] ?? null);
+
+        $properties = $component['properties'] ?? [];
+        self::assertSame('object', $properties['address']['type'] ?? null);
+        self::assertSame('array', $properties['packages']['type'] ?? null);
+        self::assertSame('object', $properties['packages']['items']['type'] ?? null);
+    }
+
+    public function testNullableTypedPropertyIsConvertedToNullableFlag(): void
+    {
+        $order = new Schema('Order');
+        $order->prop('note')->string()->nullable();
+
+        $component = $this->buildComponent($order);
+
+        $note = $component['properties']['note'] ?? [];
+        self::assertSame('string', $note['type'] ?? null);
+        self::assertTrue($note['nullable'] ?? null);
+    }
+
+    public function testNullablePropertyWithoutTypeOmitsTypeKeyword(): void
+    {
+        $order = new Schema('Order');
+        $order->prop('payload')->nullable()->description('Arbitrary payload');
+
+        $component = $this->buildComponent($order);
+
+        $payload = $component['properties']['payload'] ?? null;
+        self::assertIsArray($payload);
+        self::assertArrayNotHasKey('type', $payload);
+        self::assertArrayNotHasKey('nullable', $payload);
+        self::assertSame('Arbitrary payload', $payload['description'] ?? null);
+    }
+
+    /**
+     * @return mixed[]
+     */
+    private function buildComponent(Schema $schema): array
+    {
+        $api = new Api();
+        $api->post('/orders')->jsonRequestBody($schema);
+
+        $spec = (new OpenApiBuilder())->build($api);
+
+        $component = $spec['components']['schemas'][(string) $schema->getName()] ?? null;
+        self::assertIsArray($component);
+
+        return $component;
+    }
+}


### PR DESCRIPTION
We generate the public OpenAPI spec for our OpenApi with Schemator and ran into two issues with the generated output. The docs are rendered by Zudoku, which is stricter than Swagger Editor about what it accepts.

## Object schemas are emitted without `type: object`

`JsonSchemaBuilder::generateFromSchema()` fills `properties` and `additionalProperties` but never sets the type, so every object schema (root components, referenced schemas, `arrayOf` items) comes out without `type: object`. Swagger Editor infers the object type from the presence of `properties`, but stricter renderers don't — Zudoku for example won't render the expand toggle for nested properties unless the type is explicit.

Fixed by adding the type in `generateFromSchema()`. For nullable references this produces `type: [object, null]`, which the existing conversion in `OpenApiBuilder` already translates to `type: object` + `nullable: true`.

## Nullable properties without a type produce `type: 'null'`

A nullable property with no other type ends up with `['null']` as its type list, which `Definition::buildType()` collapses to the plain string `'null'`. The nullable conversion in `OpenApiBuilder::createComponentSchema()` only handles arrays, so `type: 'null'` leaks into the output — that's OpenAPI 3.1 syntax and 3.0 validators reject it.

Since OpenAPI 3.0 has no way to express a null-only type (`nullable` is only allowed next to another type), the conversion now drops the `type` keyword entirely in that case, leaving a schema that accepts any value. The property description can carry the null semantics.

Both changes are covered by tests and the whole suite passes (96 tests). Note that the first change also affects plain JSON Schema output — object schemas now always carry an explicit `type: object`, which is a no-op for validation but does change the generated documents.